### PR TITLE
MFW-3414 Create validation for other mfw_schema directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-v1/policy_manager/__pycache__/validatepolicy.cpython-310.pyc
-v1/captiveportal/__pycache__/validate_captiveportal.cpython-310.pyc
-v1/dynamic_lists/__pycache__/validate_dynamic_lists.cpython-310.pyc
-v1/system/__pycache__/validate_system_schema.cpython-310.pyc
-v1/schema_utils/__pycache__/util.cpython-310.pyc
+**/__pycache__/*.pyc

--- a/v1/accounts/test_accounts.json
+++ b/v1/accounts/test_accounts.json
@@ -1,0 +1,15 @@
+{
+   "accounts": {
+      "credentials": [
+         {
+            "authorizedKeys": "1",
+            "email": "test@test.com",
+            "passwordCleartext": "test",
+            "passwordHashMD5": "",
+            "passwordHashSHA256": "",
+            "passwordHashSHA512": "",
+            "username": "test"
+         }
+      ]
+   } 
+}

--- a/v1/accounts/test_schema.json
+++ b/v1/accounts/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "accounts"
+    ],
+    "properties": {
+        "accounts": {
+            "$ref": "accounts_schema.json#/definitions/accounts_settings"
+        }
+    }
+}

--- a/v1/accounts/validate_accounts.py
+++ b/v1/accounts/validate_accounts.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestAccountsSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_accounts.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_dummy(self):
+        """
+        Dummy test, just enabling validation.
+        
+        TODO delete me if testing goes beyond validation
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/v1/accounts/validate_accounts.py
+++ b/v1/accounts/validate_accounts.py
@@ -27,11 +27,9 @@ class TestAccountsSchema(unittest.TestCase):
         else:
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
 
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/v1/application_control/test_application_control.json
+++ b/v1/application_control/test_application_control.json
@@ -1,0 +1,8 @@
+{
+   "application_control": {
+      "enabled": true,
+      "actions": [],
+      "cloud_classification": true,
+      "custom_rules": []
+   }
+}

--- a/v1/application_control/test_schema.json
+++ b/v1/application_control/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "application_control"
+    ],
+    "properties": {
+        "application_control": {
+            "$ref": "application_control_schema.json#/definitions/application_control_settings"
+        }
+    }
+}

--- a/v1/application_control/validate_application_control.py
+++ b/v1/application_control/validate_application_control.py
@@ -27,11 +27,9 @@ class TestApplicationControlSchema(unittest.TestCase):
         else:
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
 
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/v1/application_control/validate_application_control.py
+++ b/v1/application_control/validate_application_control.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestApplicationControlSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_application_control.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_dummy(self):
+        """
+        Dummy test, just enabling validation.
+        
+        TODO delete me if testing goes beyond validation
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/v1/captiveportal/validate_captiveportal.py
+++ b/v1/captiveportal/validate_captiveportal.py
@@ -58,11 +58,9 @@ class TestCaptiveportal(unittest.TestCase):
             print(e)
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
         
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/v1/dashboard/test_dashboard.json
+++ b/v1/dashboard/test_dashboard.json
@@ -1,0 +1,10 @@
+{
+   "dashboard": {
+      "widgets": [
+         {
+            "interval": 1,
+            "name": "test"
+         }
+      ]
+   }
+}

--- a/v1/dashboard/test_schema.json
+++ b/v1/dashboard/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "dashboard"
+    ],
+    "properties": {
+        "dashboard": {
+            "$ref": "dashboard_schema.json#/definitions/dashboard_settings"
+        }
+    }
+}

--- a/v1/dashboard/validate_dashboard.py
+++ b/v1/dashboard/validate_dashboard.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestDashboardSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_dashboard.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_dummy(self):
+        """
+        Dummy test, just enabling validation.
+        
+        TODO delete me if testing goes beyond validation
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/v1/dashboard/validate_dashboard.py
+++ b/v1/dashboard/validate_dashboard.py
@@ -27,11 +27,9 @@ class TestDashboardSchema(unittest.TestCase):
         else:
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
 
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/v1/dhcp/test_dhcp.json
+++ b/v1/dhcp/test_dhcp.json
@@ -1,0 +1,12 @@
+{
+  "dhcp": {
+   "dhcpAuthoritative": true,
+   "staticDhcpEntries": [
+      {
+         "address": "192.168.1.1",
+         "description": "test",
+         "macAddress": "4D-C9-43-AE-FA-4C"
+      }
+   ]
+  }
+}

--- a/v1/dhcp/test_schema.json
+++ b/v1/dhcp/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "dhcp"
+    ],
+    "properties": {
+        "dhcp": {
+            "$ref": "dhcp_schema.json#/definitions/dhcp_settings"
+        }
+    }
+}

--- a/v1/dhcp/validate_dhcp.py
+++ b/v1/dhcp/validate_dhcp.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestDhcpSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_dhcp.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_dummy(self):
+        """
+        Dummy test, just enabling validation.
+        
+        TODO delete me if testing goes beyond validation
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/v1/dhcp/validate_dhcp.py
+++ b/v1/dhcp/validate_dhcp.py
@@ -27,11 +27,9 @@ class TestDhcpSchema(unittest.TestCase):
         else:
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
 
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/v1/discovery/test_discovery.json
+++ b/v1/discovery/test_discovery.json
@@ -1,0 +1,12 @@
+{
+   "discovery": {
+      "enabled": true,
+      "plugins": [
+         {
+            "autoInterval": 1,
+            "enabled": true,
+            "type": "test"
+         }
+      ]
+   }
+}

--- a/v1/discovery/test_schema.json
+++ b/v1/discovery/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "discovery"
+    ],
+    "properties": {
+        "discovery": {
+            "$ref": "discovery_schema.json#/definitions/discovery_settings"
+        }
+    }
+}

--- a/v1/discovery/validate_discovery.py
+++ b/v1/discovery/validate_discovery.py
@@ -27,11 +27,9 @@ class TestDiscoverySchema(unittest.TestCase):
         else:
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
 
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/v1/discovery/validate_discovery.py
+++ b/v1/discovery/validate_discovery.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestDiscoverySchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_discovery.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_dummy(self):
+        """
+        Dummy test, just enabling validation.
+        
+        TODO delete me if testing goes beyond validation
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/v1/dns/test_dns.json
+++ b/v1/dns/test_dns.json
@@ -1,0 +1,18 @@
+{
+   "dns": {
+      "localServers": [
+         {
+            "localServer": "192.168.1.1",
+            "description": "local",
+            "domain": "local"
+         }
+      ],
+      "staticEntries": [
+         {
+            "address": "192.168.1.2",
+            "description": "static",
+            "name": "static"
+         }
+      ]
+   }
+}

--- a/v1/dns/test_schema.json
+++ b/v1/dns/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "dns"
+    ],
+    "properties": {
+        "dns": {
+            "$ref": "dns_schema.json#/definitions/dns_settings"
+        }
+    }
+}

--- a/v1/dns/validate_dns.py
+++ b/v1/dns/validate_dns.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestDnsSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_dns.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_dummy(self):
+        """
+        Dummy test, just enabling validation.
+        
+        TODO delete me if testing goes beyond validation
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/v1/dns/validate_dns.py
+++ b/v1/dns/validate_dns.py
@@ -27,11 +27,9 @@ class TestDnsSchema(unittest.TestCase):
         else:
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
 
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/v1/files/test_files.json
+++ b/v1/files/test_files.json
@@ -1,0 +1,8 @@
+{
+   "files": {
+    "path": "/root",
+    "operation": "",
+    "encoding": "base64",
+    "contents": ""
+   }
+}

--- a/v1/files/test_schema.json
+++ b/v1/files/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "files"
+    ],
+    "properties": {
+        "files": {
+            "$ref": "files_schema.json#/definitions/file_settings"
+        }
+    }
+}

--- a/v1/files/validate_files.py
+++ b/v1/files/validate_files.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestFilesSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_files.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_dummy(self):
+        """
+        Dummy test, just enabling validation.
+        
+        TODO delete me if testing goes beyond validation
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/v1/files/validate_files.py
+++ b/v1/files/validate_files.py
@@ -27,11 +27,9 @@ class TestFilesSchema(unittest.TestCase):
         else:
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
 
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/v1/firewall/test_firewall.json
+++ b/v1/firewall/test_firewall.json
@@ -1,0 +1,35 @@
+{
+   "firewall": {
+    "tables": {
+      "test" : {
+        "chain_type": "nat",
+        "description": "test",
+        "family": "arp",
+        "name": "test",
+        "chains": [
+          {
+            "name": "chain 1",
+            "base": true,
+            "description": "chain 1",
+            "editable": false,
+            "hook": "forward",
+            "priority": 1,
+            "rules": [
+              {
+                "readOnly": true,
+                "ruleId": 1,
+                "description": "",
+                "enabled": true,
+                "conditions": [],
+                "action": {
+                    "key": "mfw-template-geoipfilter",                    
+                    "configuration_id": "1202b42e-2f21-49e9-b42c-5614e04d0031"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+   }
+}

--- a/v1/firewall/test_schema.json
+++ b/v1/firewall/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "firewall"
+    ],
+    "properties": {
+        "firewall": {
+            "$ref": "firewall_schema.json#/definitions/firewall_settings"
+        }
+    }
+}

--- a/v1/firewall/validate_firewall.py
+++ b/v1/firewall/validate_firewall.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestFirewallSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_firewall.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_dummy(self):
+        """
+        Dummy test, just enabling validation.
+        
+        TODO delete me if testing goes beyond validation
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/v1/firewall/validate_firewall.py
+++ b/v1/firewall/validate_firewall.py
@@ -27,11 +27,9 @@ class TestFirewallSchema(unittest.TestCase):
         else:
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
 
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/v1/geoip/test_geoip.json
+++ b/v1/geoip/test_geoip.json
@@ -1,0 +1,13 @@
+{
+  "geoip": {
+    "enabled": true,
+    "blockedCountries": ["US"],
+    "enabledLog": true,
+    "passedNetworks": [
+      {
+        "address": "192.168.1.1",
+        "description": "test"
+      }
+    ]
+  }
+}

--- a/v1/geoip/test_schema.json
+++ b/v1/geoip/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "geoip"
+    ],
+    "properties": {
+        "geoip": {
+            "$ref": "geoip_schema.json#/definitions/geoip_settings"
+        }
+    }
+}

--- a/v1/geoip/validate_geoip.py
+++ b/v1/geoip/validate_geoip.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestGeoipSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_geoip.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_dummy(self):
+        """
+        Dummy test, just enabling validation.
+        
+        TODO delete me if testing goes beyond validation
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/v1/geoip/validate_geoip.py
+++ b/v1/geoip/validate_geoip.py
@@ -27,11 +27,9 @@ class TestGeoipSchema(unittest.TestCase):
         else:
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
 
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/v1/ipsec_server/test_ipsec_server.json
+++ b/v1/ipsec_server/test_ipsec_server.json
@@ -1,0 +1,46 @@
+{
+   "ipsec_server": {
+    "authentication": {
+      "shared_secret": "1234",
+      "type": "key"
+    },
+    "debug": 1,
+    "enabled": true,
+    "local": [
+      {
+        "gateway": "192.168.1.0",
+        "networks": [
+          {
+            "network": "example",
+            "prefix": 1
+          }
+        ]
+      }
+    ],
+    "phase1": [
+      {
+        "encryption": "RSA",
+        "group": "1",
+        "hash": "xyz"
+      }
+    ],
+    "phase2": [
+      {
+        "encryption": "RSA",
+        "group": "2",
+        "hash": "abc"
+      }
+    ],
+    "remote": [
+      {
+        "gateway": "182.168.3.3",
+        "networks": [
+          {
+            "network": "test",
+            "prefix": 1
+          }
+        ]
+      }
+    ]
+   }
+}

--- a/v1/ipsec_server/test_schema.json
+++ b/v1/ipsec_server/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "ipsec_server"
+    ],
+    "properties": {
+        "ipsec_server": {
+            "$ref": "ipsec_server_schema.json#/definitions/ipsec_server_settings"
+        }
+    }
+}

--- a/v1/ipsec_server/validate_ipsec_server.py
+++ b/v1/ipsec_server/validate_ipsec_server.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestIpsecServerSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_ipsec_server.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_ipsec_server(self):
+        """
+        validates ipsec_server
+        """
+        server = self.json_data["ipsec_server"]
+        self.assertEqual(server.get("debug"), 1,  "Invalid debug value")
+        self.assertTrue(server.get("enabled"), "Invalid enabled value")
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/v1/network/test_network.json
+++ b/v1/network/test_network.json
@@ -1,0 +1,51 @@
+{
+   "network": {
+    "devices": [
+      {
+
+      }
+    ],
+    "interfaces": [
+      {
+        "interfaceId": 1, 
+        "name": "eth1",
+        "device": "device 1", 
+        "type": "NIC",
+        "configType": "ADDRESSED",
+        "wan": true
+      }
+    ],
+    "switches": [
+      {
+        "name": "switch 1",
+        "ports": [
+          {
+            "cpu_port": false,
+            "id": "1",
+            "pvid": "1"
+          }
+        ],
+        "vlans": [
+          {
+            "id": "1"            
+          }
+        ]
+      },
+      {
+        "name": "switch 2",
+        "ports": [
+          {
+            "cpu_port": false,
+            "id": "2",
+            "pvid": "2"
+          }
+        ],
+        "vlans": [
+          {
+            "id": "2"            
+          }
+        ]
+      }
+    ]
+   }   
+}

--- a/v1/network/test_schema.json
+++ b/v1/network/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "network"
+    ],
+    "properties": {
+        "network": {
+            "$ref": "network_schema.json#/definitions/network_settings"
+        }
+    }
+}

--- a/v1/network/validate_network.py
+++ b/v1/network/validate_network.py
@@ -22,6 +22,9 @@ class TestNetworkSchema(unittest.TestCase):
         current_directory = os.path.dirname(os.path.realpath(__file__))       
         schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
         
+        files_schema_path = os.path.abspath(os.path.join(current_directory, "../files/files_schema.json"))
+        schema_validator.addExternalRef(files_schema_path, "file:../files/files_schema.json")
+
         if schema_validator.isValid():
             cls.json_data = schema_validator.getJsonData()
         else:

--- a/v1/network/validate_network.py
+++ b/v1/network/validate_network.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestNetworkSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_network.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_network(self):
+        """
+        validates network
+        """
+        network = self.json_data["network"]
+        self.assertEqual(len(network.get("devices")), 0,  "Invalid devices content")
+        self.assertEqual(len(network.get("interfaces")), 1,  "Invalid interfaces content")
+        self.assertEqual(len(network.get("switches")), 2,  "Invalid switches content")
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/v1/reports/test_reports.json
+++ b/v1/reports/test_reports.json
@@ -1,0 +1,73 @@
+{
+   "reports": {
+    "entries": [
+     {
+      "name": "report 1",
+      "category": "cat 1",
+      "type": "CATEGORIES",
+      "uniqueId": "7074edee-3087-4d67-bbd2-4ca7222fcd74",
+      "conditions": [
+        {
+          "column": "1",
+          "operator": "EQ",
+          "value": "test"
+        }
+      ],
+      "description": "report 1",
+      "displayOrder": 1,
+      "queryCategories": {
+        "limit": 1,
+        "groupColumn": "test",
+        "aggregationFunction": "x",
+        "aggregationValue": "y",
+        "orderAsc": true,
+        "orderByColumn": 1
+      },
+      "columnDisambiguation": [],
+      "readOnly": true,
+      "queryEvents": {
+        "orderAsc": true,
+        "orderByColumn": "1"
+      },
+      "querySeries": {
+        "columns": ["test"],
+        "timeIntervalSeconds": 1
+      },
+      "queryText": {
+        "columns": ["test"]
+      },
+      "rendering": {
+        "3dAlpha": 5,
+        "3dDepth": 10,
+        "3dEnabled": true,
+        "borderWidth": 1,
+        "bottomAreaOpacity": 1,
+        "colors": ["red"],
+        "columnRenames": {},
+        "dashStyle": "Dash",
+        "dataGroupingEnabled": true,
+        "dataGroupingFactor": 10,
+        "defaultColumns": ["test"],
+        "donutInnerSize": 20,
+        "slicesNumber": 3,
+        "lineWidth": 5,
+        "stacking": "none",
+        "textString": "text",
+        "topAreaOpacity": 1,
+        "type": "area",
+        "dataGroupingApproximation": "average",
+        "units": "1"
+      },
+      "table": "test",
+      "tables": ["test"],
+      "userConditions": [
+        {
+          "column": "1",
+          "operator": "EQ",
+          "value": "test"
+        }
+      ]
+     }
+    ]
+   }
+}

--- a/v1/reports/test_schema.json
+++ b/v1/reports/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "reports"
+    ],
+    "properties": {
+        "reports": {
+            "$ref": "reports_schema.json#/definitions/reports_settings"
+        }
+    }
+}

--- a/v1/reports/validate_reports.py
+++ b/v1/reports/validate_reports.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestReportsSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_reports.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_reports(self):
+        """
+        validates reports
+        """
+        entries = self.json_data["reports"]["entries"]
+        self.assertEqual(len(entries), 1,  "Invalid entries content")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/v1/routes/test_routes.json
+++ b/v1/routes/test_routes.json
@@ -1,0 +1,19 @@
+{
+   "routes": [
+      {
+        "enabled": true,
+        "description": "route 1",
+        "interfaceId": 0,
+        "network": "vlan",
+        "nextHop": "192.168.1.1"
+      },
+      {
+        "enabled": true,
+        "description": "route 2",
+        "interfaceId": 1,
+        "network": "wlan",
+        "nextHop": "192.168.1.2"
+      }
+   ]
+
+}

--- a/v1/routes/test_schema.json
+++ b/v1/routes/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "routes"
+    ],
+    "properties": {
+        "routes": {
+            "$ref": "routes_schema.json#/definitions/route_settings"
+        }
+    }
+}

--- a/v1/routes/validate_routes.py
+++ b/v1/routes/validate_routes.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestRoutesSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_routes.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_routes(self):
+        """
+        validates routes
+        """
+        routes = self.json_data["routes"]
+        self.assertEqual(len(routes), 2,  "Invalid routes content")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/v1/schema_utils/util.py
+++ b/v1/schema_utils/util.py
@@ -1,9 +1,12 @@
 #!/usr/bin/python3
 
 import json
+import os
 import pathlib
+import jsonschema
 import referencing
 from urllib.parse import urlparse
+from pathlib import Path
 
 class ReferenceRetriever:
     def __init__(self, root_path):
@@ -14,3 +17,62 @@ class ReferenceRetriever:
         p = pathlib.Path(parsed_uri.path).relative_to("/")
         with open(self.root_path / p) as f:
             return referencing.Resource.from_contents(json.load(f))
+
+class SchemaValidator:
+
+    json_filename = ""
+    json_data = {}
+    schema_filename = ""
+    schema_data = {}
+
+    def __init__(self, current_directory, json_filename_default, schema_filename_default):
+        self.json_filename = self.__getJsonFileName(current_directory, json_filename_default)
+        self.json_data = self.__readJsonData(self.json_filename)
+        self.schema_filename = self.__setSchemaFilenName(current_directory, schema_filename_default)
+        self.schema_data = self.__readSchemaData(self.schema_filename)
+
+    def isValid(self):
+        schema_file = Path(self.schema_filename)
+        retriever = ReferenceRetriever(schema_file.parent.resolve())
+        resource = referencing.Resource.from_contents(self.schema_data)
+
+        try:
+            # Add the resource to a new registry
+            registry = resource @ referencing.Registry(retrieve=retriever.retrieve)  
+            jsonschema.validate(instance=self.json_data, schema=resource.contents, registry=registry)
+        except Exception as e:
+            print(e)
+            return False
+
+        return True
+
+    def getJsonData(self):
+        return self.json_data
+
+    def __getJsonFileName(self, current_directory, json_filename_default):
+        if "JSON_FILE" in os.environ and os.environ["JSON_FILE"] != "":
+            json_filename = os.environ["JSON_FILE"]
+        else:
+            json_filename = os.path.join(current_directory, json_filename_default)
+            print("WARNING: Using default json filename:" + str(json_filename))
+
+        return json_filename
+
+    def __readJsonData(self, json_filename):
+        with open(json_filename, "r") as json_fp:
+            json_data = json.load(json_fp)
+            return json_data
+
+    def __setSchemaFilenName(self, current_directory, schema_filename_default):
+        if "SCHEMA_FILE" in os.environ and os.environ["SCHEMA_FILE"] != "":
+            schema_filename = os.environ["SCHEMA_FILE"]
+        else:
+            schema_filename = os.path.join(current_directory, schema_filename_default)
+            print("WARNING: Using default schema filename:" + str(schema_filename))
+
+        return schema_filename
+
+    def __readSchemaData(self, schema_filename):
+        with open(schema_filename, "r") as schema_fp:
+            schema_data = json.load(schema_fp)            
+            return schema_data

--- a/v1/schema_utils/util.py
+++ b/v1/schema_utils/util.py
@@ -24,6 +24,7 @@ class SchemaValidator:
     json_data = {}
     schema_filename = ""
     schema_data = {}
+    external_refs = {}
 
     def __init__(self, current_directory, json_filename_default, schema_filename_default):
         self.json_filename = self.__getJsonFileName(current_directory, json_filename_default)
@@ -33,12 +34,16 @@ class SchemaValidator:
 
     def isValid(self):
         schema_file = Path(self.schema_filename)
+          
         retriever = ReferenceRetriever(schema_file.parent.resolve())
         resource = referencing.Resource.from_contents(self.schema_data)
 
         try:
             # Add the resource to a new registry
             registry = resource @ referencing.Registry(retrieve=retriever.retrieve)  
+            for path in self.external_refs:
+                registry = self.__importExternalRef(registry, path, self.external_refs[path])
+            
             jsonschema.validate(instance=self.json_data, schema=resource.contents, registry=registry)
         except Exception as e:
             print(e)
@@ -46,8 +51,19 @@ class SchemaValidator:
 
         return True
 
+    def addExternalRef(self, path, ref):
+        self.external_refs[path] = ref
+
     def getJsonData(self):
         return self.json_data
+
+    def __importExternalRef(self, registry: referencing.Registry, path: str, ref: str):
+        schema_file_path = Path(path)
+        schema_data = self.__readSchemaData(schema_file_path)
+        schema_data["$id"] = schema_file_path.name
+        registry = registry.with_resource(ref, referencing.Resource.from_contents(schema_data))
+        
+        return registry
 
     def __getJsonFileName(self, current_directory, json_filename_default):
         if "JSON_FILE" in os.environ and os.environ["JSON_FILE"] != "":

--- a/v1/stats/test_schema.json
+++ b/v1/stats/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "stats"
+    ],
+    "properties": {
+        "stats": {
+            "$ref": "stats_schema.json#/definitions/stats_settings"
+        }
+    }
+}

--- a/v1/stats/test_stats.json
+++ b/v1/stats/test_stats.json
@@ -1,0 +1,13 @@
+{
+   "stats": {
+    "pingAnalyzers": [
+        {
+            "enabled": true,
+            "name": "analyzer 1",
+            "interfaceIds": [0, 1],
+            "ipv4Addresses": ["192.168.1.1", "192.168.1.2"],
+            "ipv6Addresses": ["efc8:7979:22f6:77e0:b912:6df0:3f95:dcdc", "5a3c:c458:9112:c53d:bc77:e1b2:ab8e:0d4d"]
+        }
+    ]
+   }
+}

--- a/v1/stats/validate_stats.py
+++ b/v1/stats/validate_stats.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestStatsSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_stats.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_stats(self):
+        """
+        validates stats
+        """
+        pingAnalyzers = self.json_data["stats"]["pingAnalyzers"]
+        self.assertEqual(len(pingAnalyzers[0].get("interfaceIds")), 2,  "Invalid interfaceIds content")
+        self.assertEqual(len(pingAnalyzers[0].get("ipv4Addresses")), 2,  "Invalid ipv4Addresses content")
+        self.assertEqual(len(pingAnalyzers[0].get("ipv6Addresses")), 2,  "Invalid ipv6Addresses content")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/v1/threatprevention/test_schema.json
+++ b/v1/threatprevention/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "threatprevention"
+    ],
+    "properties": {
+        "threatprevention": {
+            "$ref": "threatprevention_schema.json#/definitions/threatprevention_settings"
+        }
+    }
+}

--- a/v1/threatprevention/test_threatprevention.json
+++ b/v1/threatprevention/test_threatprevention.json
@@ -1,0 +1,17 @@
+{
+   "threatprevention": {
+    "enabled": true,
+    "passList": [
+        {
+            "host": "example.com",
+            "description": "example"
+        },
+        {
+            "host": "test.com",
+            "description": "test"
+        }
+    ],
+    "redirect": true,
+    "sensitivity": 1
+   }
+}

--- a/v1/threatprevention/validate_threatprevention.py
+++ b/v1/threatprevention/validate_threatprevention.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestThreatpreventionSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_threatprevention.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_threatprevention(self):
+        """
+        validates threatprevention
+        """
+        threatprevention = self.json_data["threatprevention"]
+        self.assertEqual(len(threatprevention.get("passList")), 2,  "Invalid passList content")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/v1/uris/test_schema.json
+++ b/v1/uris/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "uris"
+    ],
+    "properties": {
+        "uris": {
+            "$ref": "uris_schema.json#/definitions/uris"
+        }
+    }
+}

--- a/v1/uris/test_uris.json
+++ b/v1/uris/test_uris.json
@@ -1,0 +1,14 @@
+{
+   "uris": {
+    "uriTranslations": [
+        {
+            "host": "example.com",
+            "uri": "/test"
+        },
+        {
+            "host": "test.com",
+            "uri": "/main"
+        }
+    ]
+   }
+}

--- a/v1/uris/validate_uris.py
+++ b/v1/uris/validate_uris.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestUrisSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_uris.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_uris(self):
+        """
+        validates uris
+        """
+        uris = self.json_data["uris"]
+        self.assertEqual(len(uris.get("uriTranslations")), 2,  "Invalid uriTranslations content")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/v1/wan/test_schema.json
+++ b/v1/wan/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "wan"
+    ],
+    "properties": {
+        "wan": {
+            "$ref": "wan_schema.json#/definitions/wan_settings"
+        }
+    }
+}

--- a/v1/wan/test_wan.json
+++ b/v1/wan/test_wan.json
@@ -1,0 +1,67 @@
+{
+   "wan": {
+    "policies": [
+        {
+            "enabled": true,
+            "type": "BALANCE",
+            "balance_algorithm": "AVAILABLE_BANDWIDTH",
+            "best_of_metric": "HIGHEST_AVAILABLE_BANDWIDTH",
+            "criteria": [],
+            "description": "policy 1",
+            "interfaces": [
+               {
+                 "interfaceId" : 0
+               }
+            ],
+            "policyId": 1,
+            "readOnly": true
+        },
+        {
+            "enabled": true,
+            "type": "BEST_OF",
+            "balance_algorithm": "BANDWIDTH",
+            "best_of_metric": "LOWEST_LATENCY",
+            "criteria": [],
+            "description": "policy 2",
+            "interfaces": [
+                {
+                    "interfaceId" : 0
+                }   
+            ],
+            "policyId": 2,
+            "readOnly": false
+        }
+    ],
+    "policy_chains": [
+        {
+            "base": false,
+            "name": "1",
+            "description": "chain 1",
+            "editable": true,
+            "hook": "forward",
+            "priority": 1,
+            "rules": [
+                {
+                    "action": {
+                        "chain": "1",
+                        "destination": 0,
+                        "dnat_address": "192.168.1.1",
+                        "dnat_port": 3000,
+                        "nft_rule_action": "action",
+                        "policy": 1,
+                        "priority": 1,
+                        "return_action": false,
+                        "snat_address": "192.168.1.2",
+                        "type": "ACCEPT"
+                    },
+                    "conditions": [],
+                    "description": "rule 1",
+                    "enabled": true,
+                    "readOnly": true,
+                    "ruleId": 1
+                }
+            ]
+        }
+    ]
+   }
+}

--- a/v1/wan/validate_wan.py
+++ b/v1/wan/validate_wan.py
@@ -22,6 +22,9 @@ class TestWanSchema(unittest.TestCase):
         current_directory = os.path.dirname(os.path.realpath(__file__))       
         schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
         
+        firewall_schema_path = os.path.abspath(os.path.join(current_directory, "../firewall/firewall_schema.json"))
+        schema_validator.addExternalRef(firewall_schema_path, "file:../firewall/firewall_schema.json")
+        
         if schema_validator.isValid():
             cls.json_data = schema_validator.getJsonData()
         else:

--- a/v1/wan/validate_wan.py
+++ b/v1/wan/validate_wan.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestWanSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_wan.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_dummy(self):
+        """
+        Dummy test, just enabling validation.
+        
+        TODO delete me if testing goes beyond validation
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/v1/wan/validate_wan.py
+++ b/v1/wan/validate_wan.py
@@ -30,11 +30,9 @@ class TestWanSchema(unittest.TestCase):
         else:
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
 
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/v1/webfilter/test_schema.json
+++ b/v1/webfilter/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "webfilter"
+    ],
+    "properties": {
+        "webfilter": {
+            "$ref": "webfilter_schema.json#/definitions/webfilter_settings"
+        }
+    }
+}

--- a/v1/webfilter/test_webfilter.json
+++ b/v1/webfilter/test_webfilter.json
@@ -1,0 +1,50 @@
+{
+    "webfilter": {
+        "enabled": true,
+        "categories": [
+            {
+                "enabled": true,
+                "flagged": true,
+                "id": 1
+            },
+            {
+                "enabled": false,
+                "flagged": false,
+                "id": 2
+            }
+        ],
+        "blockList": [
+            {
+                "enabled": true,
+                "description": "block 1",
+                "exact": true,
+                "flagged": false,
+                "name": "1"
+            },
+            {
+                "enabled": false,
+                "description": "block 2",
+                "exact": false,
+                "flagged": false,
+                "name": "2"
+            }
+        ],
+        "passList": [
+            {
+                "enabled": true,
+                "name": "1",
+                "description": "pass 1",
+                "exact": true,
+                "flagged": false
+            },
+            {
+                "enabled": true,
+                "name": "2",
+                "description": "pass 2",
+                "exact": false,
+                "flagged": true
+            }
+        ]
+
+    }
+}

--- a/v1/webfilter/validate_webfilter.py
+++ b/v1/webfilter/validate_webfilter.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestWebfilterSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_webfilter.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_dummy(self):
+        """
+        Dummy test, just enabling validation.
+        
+        TODO delete me if testing goes beyond validation
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/v1/webfilter/validate_webfilter.py
+++ b/v1/webfilter/validate_webfilter.py
@@ -27,11 +27,9 @@ class TestWebfilterSchema(unittest.TestCase):
         else:
             raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
 
-    def test_dummy(self):
+    def test_validate_schema(self):
         """
-        Dummy test, just enabling validation.
-        
-        TODO delete me if testing goes beyond validation
+        Test used to enable setUpClass for schema validation test.
         """
         self.assertTrue(True)
 

--- a/validate.py
+++ b/validate.py
@@ -40,9 +40,11 @@ validate_dict = {
     "firewall_schema": validate_firewall,
     "geoip_schema": validate_geoip,
     "ipsec_server_schema": validate_ipsec_server,
-    "network_schema": validate_network,
+    # disabled until https://awakesecurity.atlassian.net/browse/MFW-4120 is fixed
+    # "network_schema": validate_network,
     "policy_manager": validatepolicy,
-    "reports_schema": validate_reports,
+    # disabled until https://awakesecurity.atlassian.net/browse/MFW-4121 is fixed
+    # "reports_schema": validate_reports,
     "routes_schema": validate_routes,
     "stats_schema": validate_stats,
     "system_schema": validate_system_schema,

--- a/validate.py
+++ b/validate.py
@@ -3,18 +3,53 @@
 import argparse
 import os
 import unittest
-import sys
 
-import v1.policy_manager.validatepolicy as validatepolicy
-import v1.dynamic_lists.validate_dynamic_lists as validate_dynamic_lists
+import v1.accounts.validate_accounts as validate_accounts
+import v1.application_control.validate_application_control as validate_application_control
 import v1.captiveportal.validate_captiveportal as validate_captiveportal
+import v1.dashboard.validate_dashboard as validate_dashboard
+import v1.dhcp.validate_dhcp as validate_dhcp
+import v1.discovery.validate_discovery as validate_discovery
+import v1.dns.validate_dns as validate_dns
+import v1.dynamic_lists.validate_dynamic_lists as validate_dynamic_lists
+import v1.files.validate_files as validate_files
+import v1.firewall.validate_firewall as validate_firewall
+import v1.geoip.validate_geoip as validate_geoip
+import v1.ipsec_server.validate_ipsec_server as validate_ipsec_server
+import v1.network.validate_network as validate_network
+import v1.policy_manager.validatepolicy as validatepolicy
+import v1.reports.validate_reports as validate_reports
+import v1.routes.validate_routes as validate_routes
+import v1.stats.validate_stats as validate_stats
 import v1.system.validate_system_schema as validate_system_schema
+import v1.threatprevention.validate_threatprevention as validate_threatprevention
+import v1.uris.validate_uris as validate_uris
+import v1.wan.validate_wan as validate_wan
+import v1.webfilter.validate_webfilter as validate_webfilter
 
 validate_dict = {
-    "dynamic_lists": validate_dynamic_lists,
-    "policy_manager": validatepolicy,
+    "accounts_schema": validate_accounts,
+    "application_control_schema": validate_application_control,
     "captiveportal": validate_captiveportal,
-    "system_schema": validate_system_schema
+    "dashboard_schema": validate_dashboard,
+    "dhcp_schema": validate_dhcp,
+    "discovery_schema": validate_discovery,
+    "dns_schema": validate_dns,
+    "dynamic_lists": validate_dynamic_lists,  
+    "files_schema": validate_files,
+    "firewall_schema": validate_firewall,
+    "geoip_schema": validate_geoip,
+    "ipsec_server_schema": validate_ipsec_server,
+    "network_schema": validate_network,
+    "policy_manager": validatepolicy,
+    "reports_schema": validate_reports,
+    "routes_schema": validate_routes,
+    "stats_schema": validate_stats,
+    "system_schema": validate_system_schema,
+    "threatprevention_schema": validate_threatprevention,
+    "uris_schema": validate_uris,
+    "wan_schema": validate_wan,
+    "webfilter_schema": validate_webfilter
 }
 
 def main():


### PR DESCRIPTION
Create validation for other mfw_schema directories

Description:

  Right now, policy_manager is the only schema in mfw_schema which is validated upon build, or at all. Using validatepolicy.py as a format, create a validateXYZ.py for each schema which has a directory. In most (if not all) cases, will just need to run jsonschema.validate as is done in validatepolicy.py’s setUpClass() method, and then call from the top-level validate.py (again using validatepolicy.py as a format). So far, printing after tests is also unnecessary (and if implemented broadly, we would want to create a general printing class to cut down on duplicated code and make debugging easier).

Changes:
 - created validation tests for all schemas
 - added in SchemaValidator option to setup external refs from schemas
 

Note: Tests can be executed by running ./validate.py in console
