### PR TITLE
MFW-4523 Added a mteric field to route schema

### DIFF
--- a/v1/routes/routes_schema.json
+++ b/v1/routes/routes_schema.json
@@ -30,6 +30,10 @@
                 "nextHop": {
                     "type": "string",
                     "description": "The nexthop/gateway of the static route definition"
+                },
+                "metric": {
+                    "type": "number",
+                    "description": "Specifies the route metric to use"
                 }
             }
         }

--- a/v1/routes/test_routes.json
+++ b/v1/routes/test_routes.json
@@ -14,7 +14,7 @@
          "interfaceId": 1,
          "network": "wlan",
          "nextHop": "192.168.1.2",
-          "metric": 0
+         "metric": 0
        }
     ]
  

--- a/v1/routes/test_routes.json
+++ b/v1/routes/test_routes.json
@@ -1,0 +1,21 @@
+{
+    "routes": [
+       {
+         "enabled": true,
+         "description": "route 1",
+         "interfaceId": 0,
+         "network": "vlan",
+         "nextHop": "192.168.1.1",
+         "metric": 0
+       },
+       {
+         "enabled": true,
+         "description": "route 2",
+         "interfaceId": 1,
+         "network": "wlan",
+         "nextHop": "192.168.1.2",
+          "metric": 0
+       }
+    ]
+ 
+ }

--- a/v1/routes/validate_routes.py
+++ b/v1/routes/validate_routes.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+
+class TestRoutesSchema(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "test_routes.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    json_data = {}
+    
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))       
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+
+    def test_routes(self):
+        """
+        validates routes
+        """
+        routes = self.json_data["routes"]
+        self.assertEqual(len(routes), 2,  "Invalid routes content")
+
+        for i, route in enumerate(routes):
+            metric_value = route.get("metric", None)
+            if metric_value:
+                self.assertTrue(isinstance(metric_value, int), f"Invalid metric unit for route {i + 1}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Problem: Add 'metric' property in static routes schema

Changes: added a new field 'metric' to route schema

Testing instructions:
Run the test cases by using command ./validate.py in mfw_schema
Check all test cases passed or not

Expected Result:
All the test cases from route_schema should pass
Please refer below output for reference
```
=== START OF MODULE TEST: <module 'v1.routes.validate_routes' from '/home/vishal/Desktop/bug/4523/mfw_schema/v1/routes/validate_routes.py'> ===

WARNING: Using default json filename:/home/vishal/Desktop/bug/4523/mfw_schema/v1/routes/test_routes.json
WARNING: Using default schema filename:/home/vishal/Desktop/bug/4523/mfw_schema/v1/routes/test_schema.json
test_routes (v1.routes.validate_routes.TestRoutesSchema)
validates routes ... ok

----------------------------------------------------------------------
Ran 1 test in 0.001s

OK
=== END OF MODULE TEST: <module 'v1.routes.validate_routes' from '/home/vishal/Desktop/bug/4523/mfw_schema/v1/routes/validate_routes.py'> ===
```