### PR TITLE
MFW-4743: add system.databases schema

### DIFF
--- a/v1/system/system_schema.json
+++ b/v1/system/system_schema.json
@@ -136,6 +136,12 @@
                 }
             }
         },
+        "database_list_settings": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/database_config_settings"
+            }
+        },
         "database_config_settings": {
             "type": "object",
             "properties": {
@@ -184,12 +190,6 @@
                     "type": "string"
                 }
     
-            }
-        },
-        "database_list_settings": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/database_config_settings"
             }
         }
     }

--- a/v1/system/system_schema.json
+++ b/v1/system/system_schema.json
@@ -140,14 +140,15 @@
             "type": "object",
             "properties": {
                 "name": {
-                    "description": "database name",
+                    "description": "DB Connection name (this will be shown on UI)",
                     "type": "string"
                 },
                 "description": {
+                    "description": "Additional description for the DB Connection",
                     "type": "string"
                 },
                 "id": {
-                    "description": "id for Database",
+                    "description": "UUID for Database (auto-generated)",
                     "type": "string"
                 },
                 "type": {
@@ -155,7 +156,7 @@
                     "type": "string"
                 },
                 "enabled": {
-                    "description": "Database enabled/disabled",
+                    "description": "Database Connection enabled/disabled",
                     "type": "boolean"
                 },
                 "db_server": {
@@ -169,6 +170,10 @@
                 "db_username": {
                     "description": "Username for the Database.",
                     "type": "string"
+                },
+                "db_port": {
+                    "description": "Database Port",
+                    "type": "integer"
                 },
                 "db_password": {
                     "description": "Database password for the given user.",

--- a/v1/system/system_schema.json
+++ b/v1/system/system_schema.json
@@ -17,7 +17,8 @@
                 "setupWizard": { "$ref": "#/definitions/setup_wizard_settings" },
                 "autoUpgrade": { "$ref": "#/definitions/auto_settings" },
                 "autoBackup": { "$ref": "#/definitions/auto_settings" },
-                "logging": { "$ref": "#/definitions/logging" }
+                "logging": { "$ref": "#/definitions/logging" },
+                "databases": { "$ref": "#/definitions/databases_settings" }
             }
         },
         "logging": {
@@ -133,6 +134,57 @@
                     "minimum": 0,
                     "maximum": 59
                 }
+            }
+        },
+        "database_settings": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "database name",
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "uuid": {
+                    "description": "uuid for Database",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Database type i.e. MySQL,postgres",
+                    "type": "string"
+                },
+                "enabled": {
+                    "description": "Database enabled/disabled",
+                    "type": "boolean"
+                },
+                "db_server": {
+                    "description": "Remote Host/Server",
+                    "type": "string"
+                },
+                "db_name": {
+                    "description": "Name of the Database.",
+                    "type": "string"
+                },
+                "db_username": {
+                    "description": "Username for the Database.",
+                    "type": "string"
+                },
+                "db_password": {
+                    "description": "Database password for the given user.",
+                    "type": "string"
+                },
+                "db_connection_string": {
+                    "description": "Connection String",
+                    "type": "string"
+                }
+    
+            }
+        },
+        "databases_settings": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/database_settings"
             }
         }
     }

--- a/v1/system/system_schema.json
+++ b/v1/system/system_schema.json
@@ -136,7 +136,7 @@
                 }
             }
         },
-        "database_settings": {
+        "database_config_settings": {
             "type": "object",
             "properties": {
                 "name": {
@@ -189,7 +189,7 @@
         "databases_settings": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/database_settings"
+                "$ref": "#/definitions/database_config_settings"
             }
         }
     }

--- a/v1/system/system_schema.json
+++ b/v1/system/system_schema.json
@@ -18,7 +18,7 @@
                 "autoUpgrade": { "$ref": "#/definitions/auto_settings" },
                 "autoBackup": { "$ref": "#/definitions/auto_settings" },
                 "logging": { "$ref": "#/definitions/logging" },
-                "databases": { "$ref": "#/definitions/databases_settings" }
+                "databases": { "$ref": "#/definitions/database_list_settings" }
             }
         },
         "logging": {
@@ -186,7 +186,7 @@
     
             }
         },
-        "databases_settings": {
+        "database_list_settings": {
             "type": "array",
             "items": {
                 "$ref": "#/definitions/database_config_settings"

--- a/v1/system/system_schema.json
+++ b/v1/system/system_schema.json
@@ -146,8 +146,8 @@
                 "description": {
                     "type": "string"
                 },
-                "uuid": {
-                    "description": "uuid for Database",
+                "id": {
+                    "description": "id for Database",
                     "type": "string"
                 },
                 "type": {

--- a/v1/system/test_system_schema.json
+++ b/v1/system/test_system_schema.json
@@ -10,6 +10,7 @@
             "db_server": "123.456.789.4",
             "db_name": "clientDetails",
             "db_username": "dev",
+            "db_port": 5023,
             "db_password": "S@mple#",
             "db_connection_string": "postgresql://dev:S@mple#@123.456.789.4/clientDetails"
         }

--- a/v1/system/test_system_schema.json
+++ b/v1/system/test_system_schema.json
@@ -1,5 +1,19 @@
 {
   "system": {
+      "databases": [
+        {
+            "name": "postgres-connection",
+            "description": "external postgres DB",
+            "uuid": "5aeaded8-074e-40b7-8421-5366a2550e11",
+            "type": "postgres",
+            "enabled": true,
+            "db_server": "123.456.789.4",
+            "db_name": "clientDetails",
+            "db_username": "dev",
+            "db_password": "S@mple#",
+            "db_connection_string": "postgresql://dev:S@mple#@123.456.789.4/clientDetails"
+        }
+      ],
       "autoBackup": {
           "dayOfWeek": 1,
           "enabled": true,

--- a/v1/system/test_system_schema.json
+++ b/v1/system/test_system_schema.json
@@ -4,7 +4,7 @@
         {
             "name": "postgres-connection",
             "description": "external postgres DB",
-            "uuid": "5aeaded8-074e-40b7-8421-5366a2550e11",
+            "id": "5aeaded8-074e-40b7-8421-5366a2550e11",
             "type": "postgres",
             "enabled": true,
             "db_server": "123.456.789.4",


### PR DESCRIPTION
JIRA:
https://awakesecurity.atlassian.net/browse/MFW-4743

example of settings.json that will be supported to configure a Database.
```json
  "system": {
      "databases": [
         {
            "name": "postgres-connection",
            "description": "external postgres DB",
            "id": "5aeaded8-074e-40b7-8421-5366a2550e11",
            "type": "postgres",
            "enabled": true,
            "db_server": "123.456.789.4",
            "db_name": "clientDetails",
            "db_username": "dev",
            "db_port": 5023,
            "db_password": "S@mple#",
            "db_connection_string": "postgresql://dev:S@mple#@123.456.789.4:1234/clientDetails"
        }
      ],
      ... 
  }
  ```