### PR TITLE
MFW-4965: Create settings schema to store/save DOS configurations

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -117,7 +117,8 @@
                 "./v1/webfilter/webfilter_schema.json",
                 "./v1/captiveportal/captiveportal_schema.json",
                 "./v1/quota_manager/quota_manager_schema.json",
-                "./v1/databases/databases_schema.json"
+                "./v1/databases/databases_schema.json",
+                "./v1/denialofservice/denialofservice_schema.json"
             ],
             "default": ""
         },
@@ -131,7 +132,8 @@
                 "./v1/policy_manager/test_settings.json",
                 "./v1/captiveportal/captiveportal_test.json",
                 "./v1/quota_manager/quota_manager_test.json",
-                "./v1/databases/databases_test.json"
+                "./v1/databases/databases_test.json",
+                "./v1/denialofservice/denialofservice_test.json"
             ],
             "default": ""
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -63,7 +63,16 @@
                 "kind": "test",
                 "isDefault": true
             }
-        }
+        },
+        {
+            "label": "Test denialofservice",
+            "type": "shell",
+            "command": "./validate.py denialofservice v1/denialofservice/test_schema.json v1/denialofservice/denialofservice_test.json",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        },
     ],
     "inputs": [
         {

--- a/v1/denialofservice/denialofservice_schema.json
+++ b/v1/denialofservice/denialofservice_schema.json
@@ -1,0 +1,68 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:denialofservice_schema.json",
+    "definitions": {
+        "denialofservice_settings": {
+            "type": "object",
+            "description": "Denial of Service settings",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "source_sessions_max_tcp": {
+                "type": "number",
+                "description": "Maximum number of source TCP sessions"
+              },
+              "source_sessions_max_udp": {
+                "type": "number",
+                "description": "Maximum number of source UDP sessions"
+              },
+              "source_sessions_max_icmp": {
+                "type": "number",
+                "description": "Maximum number of source ICMP sessions"
+              },
+              "source_sessions_max_other": {
+                "type": "number",
+                "description": "Maximum number of other source sessions"
+              },
+              "dest_sessions_max_tcp": {
+                "type": "number",
+                "description": "Maximum number of destination TCP sessions"
+              },
+              "dest_sessions_max_udp": {
+                "type": "number",
+                "description": "Maximum number of destination UDP sessions"
+              },
+              "dest_sessions_max_icmp": {
+                "type": "number",
+                "description": "Maximum number of destination ICMP sessions"
+              },
+              "dest_sessions_max_other": {
+                "type": "number",
+                "description": "Maximum number of other destination sessions"
+              },
+              "new_sessions_per_second_tcp": {
+                "type": "number",
+                "description": "New TCP sessions allowed per second"
+              },
+              "new_sessions_per_second_udp": {
+                "type": "number",
+                "description": "New UDP sessions allowed per second"
+              },
+              "new_sessions_per_second_icmp": {
+                "type": "number",
+                "description": "New ICMP sessions allowed per second"
+              },
+              "block_duration": {
+                "type": "number",
+                "description": "Duration to block sessions (in seconds)"
+              },
+              "remove_active_sessions": {
+                "type": "boolean",
+                "description": "Indicates whether to remove active sessions"
+              }
+            }
+                 
+        }
+    }
+}

--- a/v1/denialofservice/denialofservice_test.json
+++ b/v1/denialofservice/denialofservice_test.json
@@ -1,0 +1,19 @@
+{
+    "Denialofservice":{
+        "enabled": true,    
+        "source_sessions_max_tcp": 5000,
+        "source_sessions_max_udp": 5000,
+        "source_sessions_max_icmp": 300,
+        "source_sessions_max_other": 5000,      
+        "dest_sessions_max_tcp": 5000,
+        "dest_sessions_max_udp": 5000,
+        "dest_sessions_max_icmp": 1000,
+        "dest_sessions_max_other": 5000,     
+        "new_sessions_per_second_tcp": 2000,
+        "new_sessions_per_second_udp": 2000,
+        "new_sessions_per_second_icmp": 250,      
+        "block_duration": 300,
+        "remove_active_sessions": true
+      }
+      
+}

--- a/v1/denialofservice/denialofservice_test.json
+++ b/v1/denialofservice/denialofservice_test.json
@@ -1,5 +1,5 @@
 {
-    "Denialofservice":{
+    "denialofservice":{
         "enabled": true,    
         "source_sessions_max_tcp": 5000,
         "source_sessions_max_udp": 5000,

--- a/v1/denialofservice/test_schema.json
+++ b/v1/denialofservice/test_schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "file:test_schema.json",
+    "description": "schema for the JSON settings",
+    "type": "object",
+    "required": [
+        "denialofservice"
+    ],
+    "properties": {
+        "denialofservice": {
+            "$ref": "denialofservice_schema.json#/definitions/denialofservice_settings"
+        }
+    }
+}

--- a/v1/denialofservice/validate_denialofservice.py
+++ b/v1/denialofservice/validate_denialofservice.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python3
+
+import os
+import unittest
+
+from v1.schema_utils.util import SchemaValidator
+
+"""
+TestDenialofservice validates the denialofservice schema
+
+Unlike other tests like TestPolicyManager, this just validates the schema since there are no further required tests.
+"""
+class TestDenialofservice(unittest.TestCase):
+    # consts
+    JSON_FILENAME_DEFAULT = "denialofservice_test.json"
+    SCHEMA_FILENAME_DEFAULT = "test_schema.json"
+    # class vars, begin uninitialized
+    json_data = ""
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        setUpClass runs before all tests. Grabs file information, using some defaults if the environment variables 
+        fail for any reason. Then performs the regular jsonschema.validate, to check against the schema. This errors 
+        out, so any follow-up tests won't run
+        """
+        current_directory = os.path.dirname(os.path.realpath(__file__))
+        schema_validator = SchemaValidator(current_directory, cls.JSON_FILENAME_DEFAULT, cls.SCHEMA_FILENAME_DEFAULT)
+        
+        if schema_validator.isValid():
+            cls.json_data = schema_validator.getJsonData()
+        else:
+            raise unittest.SkipTest("ERROR: Validation of schema failed. Skipping all tests and printing.")
+        
+    def test_validate_schema(self):
+        """
+        Test used to enable setUpClass for schema validation test.
+        """
+        self.assertTrue(True)
+
+if __name__ == '__main__':
+    
+    unittest.main()

--- a/validate.py
+++ b/validate.py
@@ -7,6 +7,7 @@ import unittest
 import v1.accounts.validate_accounts as validate_accounts
 import v1.application_control.validate_application_control as validate_application_control
 import v1.captiveportal.validate_captiveportal as validate_captiveportal
+import v1.denialofservice.validate_denialofservice as validate_denialofservice
 import v1.dashboard.validate_dashboard as validate_dashboard
 import v1.databases.validate_databases_schema as validate_databases
 import v1.dhcp.validate_dhcp as validate_dhcp
@@ -36,6 +37,7 @@ validate_dict = {
     "application_control_schema": validate_application_control,
     "captiveportal": validate_captiveportal,
     "dashboard_schema": validate_dashboard,
+    "denialofservice": validate_denialofservice,
     "dhcp_schema": validate_dhcp,
     "discovery_schema": validate_discovery,
     "dns_schema": validate_dns,

--- a/validate.py
+++ b/validate.py
@@ -7,9 +7,9 @@ import unittest
 import v1.accounts.validate_accounts as validate_accounts
 import v1.application_control.validate_application_control as validate_application_control
 import v1.captiveportal.validate_captiveportal as validate_captiveportal
-import v1.denialofservice.validate_denialofservice as validate_denialofservice
 import v1.dashboard.validate_dashboard as validate_dashboard
 import v1.databases.validate_databases_schema as validate_databases
+import v1.denialofservice.validate_denialofservice as validate_denialofservice
 import v1.dhcp.validate_dhcp as validate_dhcp
 import v1.discovery.validate_discovery as validate_discovery
 import v1.dns.validate_dns as validate_dns


### PR DESCRIPTION
Story: MFW-4965 Create settings schema to store/save DOS configurations
Update: Added schema for DOS configurations'
**Test cases** :
Pass: 
![pass_scenario](https://github.com/user-attachments/assets/688c03ae-541e-4f8b-a4cb-fd9697022780)
Fail:
![fail_scenario](https://github.com/user-attachments/assets/6a2fa6ef-bc8e-4807-af7a-d9b32249f728)

