### PR TITLE
MFW-5963 Changing name size to 15

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -100,6 +100,15 @@
                 "isDefault": true
             }
         },
+        {
+            "label": "Test Network",
+            "type": "shell",
+            "command": "./validate.py network_schema v1/network/test_schema.json v1/network/test_network.json",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        },
     ],
     "inputs": [
         {

--- a/v1/network/network_schema.json
+++ b/v1/network/network_schema.json
@@ -86,7 +86,7 @@
                 "name": {
                     "type": "string",
                     "description": "Human readable name",
-                    "maxLength": 8,
+                    "maxLength": 15,
                     "minLength": 1
                 },
                 "enabled": {

--- a/v1/network/network_schema.json
+++ b/v1/network/network_schema.json
@@ -72,6 +72,11 @@
                 }
             }
         },
+        "device_settings": {
+            "type": "object",
+            "name": "string",
+            "description": "string"
+        },
         "interface_settings": {
             "type": "object",
             "description": "interface settings",

--- a/v1/network/test_network.json
+++ b/v1/network/test_network.json
@@ -2,7 +2,8 @@
    "network": {
     "devices": [
       {
-
+        "name": "enp0s3",
+        "description": "dummy device"
       }
     ],
     "interfaces": [
@@ -13,7 +14,16 @@
         "type": "NIC",
         "configType": "ADDRESSED",
         "wan": true
+      },
+      {
+        "interfaceId": 2, 
+        "name": "e12345678901234",
+        "device": "device 2", 
+        "type": "NIC",
+        "configType": "ADDRESSED",
+        "wan": false
       }
+
     ],
     "switches": [
       {

--- a/v1/network/validate_network.py
+++ b/v1/network/validate_network.py
@@ -35,8 +35,9 @@ class TestNetworkSchema(unittest.TestCase):
         validates network
         """
         network = self.json_data["network"]
-        self.assertEqual(len(network.get("devices")), 0,  "Invalid devices content")
-        self.assertEqual(len(network.get("interfaces")), 1,  "Invalid interfaces content")
+        self.assertEqual(len(network.get("devices")), 1,  "Invalid devices content")
+        self.assertEqual(len(network.get("interfaces")), 2,  "Invalid interfaces content")
+        self.assertEqual(len(network.get("interfaces")[1].get("name")), 15, "Interface name should support size 15")
         self.assertEqual(len(network.get("switches")), 2,  "Invalid switches content")
 
 if __name__ == '__main__':

--- a/validate.py
+++ b/validate.py
@@ -50,8 +50,7 @@ validate_dict = {
     "geoip_schema": validate_geoip,
     "ipsec_server_schema": validate_ipsec_server,
     "logger_schema" : validate_logger,
-    # disabled until https://awakesecurity.atlassian.net/browse/MFW-4120 is fixed
-    # "network_schema": validate_network,
+    "network_schema": validate_network,
     "policy_manager": validatepolicy,
     # disabled until https://awakesecurity.atlassian.net/browse/MFW-4121 is fixed
     # "reports_schema": validate_reports,


### PR DESCRIPTION
The network schema test was disabled. I enabled it and added a test case for a 15 character interface name.